### PR TITLE
[ DD ] Airbnb clone coding - Calendar

### DIFF
--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -223,6 +223,7 @@ header .calendar-container > .calendar-fixed-box {
   left: 0;
   right: 0;
   background: none;
+  z-index: 2;
 }
 header .calendar-fixed-box > .calendar-day-control {
   display: flex;
@@ -249,6 +250,7 @@ header .calendar-list > .translate-box {
   padding: 0 1rem;
   display: flex;
   transform: translate(-25.1rem);
+  transition: all 1s ease;
 }
 header .translate-box > div + div {
   margin-left: 3rem;

--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -180,6 +180,7 @@ header .searchItem-floatBox {
   display: flex;
   top: 5rem;
   width: 100%;
+  box-sizing: border-box;
 }
 header .searchItem-floatBox.item-location {
   justify-content: flex-start;
@@ -206,7 +207,41 @@ header .location-list > li > img {
   margin-right: 1rem;
 }
 header .searchItem-floatBox.item-calendar {
-  justify-content: center;
+  background: white;
+  flex-direction: column;
+  border-radius: 2rem;
+  color: black;
+  padding: 3rem;
+  height: 25rem;
+}
+header .calendar-box {
+  position: relative;
+}
+header .calendar-box > .calendar-fixed-box {
+  position: absolute;
+  left: 0;
+  right: 0;
+}
+header .calendar-fixed-box > .calendar-day-control {
+  display: flex;
+  justify-content: space-between;
+}
+header .calendar-fixed-box .calendar-day-box {
+  display: flex;
+  justify-content: space-between;
+  padding: 1rem;
+}
+header .calendar-fixed-box .calendar-day {
+  display: flex;
+  width: 47%;
+}
+header .calendar-day li {
+  width: 14.28%;
+  text-align: center;
+}
+
+header .calendar-option > ul {
+  display: flex;
 }
 header .searchItem-floatBox.item-guest {
   justify-content: flex-end;
@@ -430,4 +465,8 @@ footer .contents_wrapper > div:first-child {
 
 .footer-down ul {
   display: flex;
+}
+
+* {
+  outline: 1px solid red;
 }

--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -214,13 +214,15 @@ header .searchItem-floatBox.item-calendar {
   padding: 3rem;
   height: 25rem;
 }
-header .calendar-box {
+
+header .calendar-container {
   position: relative;
 }
-header .calendar-box > .calendar-fixed-box {
+header .calendar-container > .calendar-fixed-box {
   position: absolute;
   left: 0;
   right: 0;
+  background: none;
 }
 header .calendar-fixed-box > .calendar-day-control {
   display: flex;
@@ -240,6 +242,43 @@ header .calendar-day li {
   text-align: center;
 }
 
+header .calendar-container > .calendar-list {
+  overflow: hidden;
+}
+header .calendar-list > .translate-box {
+  padding: 0 1rem;
+  display: flex;
+  transform: translate(-25.1rem);
+}
+header .translate-box > div + div {
+  margin-left: 3rem;
+}
+
+header .calendar-date {
+  width: 22.1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+header .calendar-box ul {
+  margin-top: 3rem;
+  display: flex;
+  flex-wrap: wrap;
+}
+header .calendar-box ul > li {
+  width: 14.28%;
+  height: 0;
+  padding: 7.14% 0;
+  border-radius: 4rem;
+  box-sizing: border-box;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+header .calendar-box ul > li:hover {
+  box-shadow: 0 0 0 1px black;
+}
 header .calendar-option > ul {
   display: flex;
 }
@@ -465,8 +504,4 @@ footer .contents_wrapper > div:first-child {
 
 .footer-down ul {
   display: flex;
-}
-
-* {
-  outline: 1px solid red;
 }

--- a/dist/index.html
+++ b/dist/index.html
@@ -244,5 +244,3 @@
     <script src="./js/main.js" type="module"></script>
   </body>
 </html>
-
-

--- a/dist/index.html
+++ b/dist/index.html
@@ -244,3 +244,4 @@
     <script src="./js/main.js" type="module"></script>
   </body>
 </html>
+

--- a/dist/js/components/header/search/SearchBox.js
+++ b/dist/js/components/header/search/SearchBox.js
@@ -5,7 +5,7 @@ import Guest from "./searchItem/Guest.js";
 export default class SearchBox extends Component {
   setup() {
     this.state = {
-      searchItem: "",
+      searchItem: "stayCheckIn",
     };
   }
   getTemplate() {
@@ -83,7 +83,6 @@ export default class SearchBox extends Component {
     `;
   }
   mounted() {
-    
     const searchItems = {
       "": () => {},
       searchLocation: ($target, props) => new Location($target, props),
@@ -93,8 +92,8 @@ export default class SearchBox extends Component {
       experienceDate: ($target, props) => new Calendar($target, props),
     };
     const $searchItemFloatBox = this.$target.querySelector(
-        ".searchItem-floatBox"
-      );
+      ".searchItem-floatBox"
+    );
     const { searchItem } = this.state;
     const createFloatBox = searchItems[searchItem];
     createFloatBox($searchItemFloatBox);

--- a/dist/js/components/header/search/SearchBox.js
+++ b/dist/js/components/header/search/SearchBox.js
@@ -91,6 +91,7 @@ export default class SearchBox extends Component {
       stayGuest: ($target, props) => new Guest($target, props),
       experienceDate: ($target, props) => new Calendar($target, props),
     };
+
     const $searchItemFloatBox = this.$target.querySelector(
       ".searchItem-floatBox"
     );
@@ -106,3 +107,28 @@ export default class SearchBox extends Component {
     });
   }
 }
+
+// {
+//   year: 2021,
+//   month: 1,
+//   day: 31,
+//   firstDay: 5,
+// },
+// {
+//   year: 2021,
+//   month: 2,
+//   day: 28,
+//   firstDay: 1,
+// },
+// {
+//   year: 2021,
+//   month: 3,
+//   day: 31,
+//   firstDay: 1,
+// },
+// {
+//   year: 2021,
+//   month: 4,
+//   day: 30,
+//   firstDay: 4,
+// },

--- a/dist/js/components/header/search/searchItem/Calendar.js
+++ b/dist/js/components/header/search/searchItem/Calendar.js
@@ -2,12 +2,46 @@ import Component from "../../../../core/Component.js";
 
 export default class Calendar extends Component {
   setup() {
-    this.$target.classList.add("calendar");
+    this.$target.classList.add("item-calendar");
   }
   getTemplate() {
     return `
-        <div>hi~</div>
+    <div class="calendar-box">
+      <div class="calendar-fixed-box">
+        <div class="calendar-day-control">
+          <div>&lt;</div>
+          <div>&gt;</div>
+        </div>
+        <div class="calendar-day-box">
+          <ul class="calendar-day">
+          <li>일</li>
+          <li>월</li>
+          <li>화</li>
+          <li>수</li>
+          <li>목</li>
+          <li>금</li>
+          <li>토</li>
+        </ul>
+        <ul class="calendar-day">
+          <li>일</li>
+          <li>월</li>
+          <li>화</li>
+          <li>수</li>
+          <li>목</li>
+          <li>금</li>
+          <li>토</li>
+        </ul>
+        </div>
+        <div class="calendar-list"></div>
+      </div>
+      <div class="calendar-date">
+      </div>
+  </div>
+  <div class="calendar-option">
+    
+  </div>
         `;
   }
   setEvent() {}
+  createCalendar() {}
 }

--- a/dist/js/components/header/search/searchItem/Calendar.js
+++ b/dist/js/components/header/search/searchItem/Calendar.js
@@ -3,45 +3,111 @@ import Component from "../../../../core/Component.js";
 export default class Calendar extends Component {
   setup() {
     this.$target.classList.add("item-calendar");
+    this.state = {
+      currentDate: this.getCurrentDate(),
+      startDay: {
+        year: 2021,
+        month: 2,
+        day: 12,
+      },
+      endDay: {
+        year: 2021,
+        month: 2,
+        day: 15,
+      },
+      calendars: [],
+    };
+    this.initdefaultState();
+  }
+  initdefaultState() {
+    const [year, month] = this.state.currentDate;
+    this.state.calendars = [
+      this.getDateState(year, month - 1),
+      this.getDateState(year, month),
+      this.getDateState(year, month + 1),
+      this.getDateState(year, month + 2),
+    ];
+  }
+  getDateState(year, month) {
+    console.log(year, month);
+    const date = new Date(year, month, 0);
+    const firstDay = new Date(year, month, 1);
+    console.log(firstDay.getDay());
+    console.log(" ");
+    return {
+      year: date.getFullYear(),
+      month: date.getMonth() + 1,
+      day: date.getDate(),
+      firstDay: firstDay.getDay(),
+    };
+  }
+  getCurrentDate() {
+    const current = new Date();
+    return [current.getFullYear(), current.getMonth()];
   }
   getTemplate() {
+    const { startDay, endDay, calendars } = this.state;
     return `
-    <div class="calendar-box">
-      <div class="calendar-fixed-box">
-        <div class="calendar-day-control">
-          <div>&lt;</div>
-          <div>&gt;</div>
-        </div>
-        <div class="calendar-day-box">
-          <ul class="calendar-day">
-          <li>일</li>
-          <li>월</li>
-          <li>화</li>
-          <li>수</li>
-          <li>목</li>
-          <li>금</li>
-          <li>토</li>
-        </ul>
-        <ul class="calendar-day">
-          <li>일</li>
-          <li>월</li>
-          <li>화</li>
-          <li>수</li>
-          <li>목</li>
-          <li>금</li>
-          <li>토</li>
-        </ul>
-        </div>
-        <div class="calendar-list"></div>
-      </div>
-      <div class="calendar-date">
-      </div>
+<div class="calendar-container">
+  <div class="calendar-fixed-box">
+    <div class="calendar-day-control">
+      <div>&lt;</div>
+      <div>&gt;</div>
+    </div>
+    <div class="calendar-day-box">
+      <ul class="calendar-day">
+        <li>일</li>
+        <li>월</li>
+        <li>화</li>
+        <li>수</li>
+        <li>목</li>
+        <li>금</li>
+        <li>토</li>
+      </ul>
+      <ul class="calendar-day">
+        <li>일</li>
+        <li>월</li>
+        <li>화</li>
+        <li>수</li>
+        <li>목</li>
+        <li>금</li>
+        <li>토</li>
+      </ul>
+    </div>
   </div>
-  <div class="calendar-option">
-    
+  <div class="calendar-list">
+    <div class="translate-box">
+    ${calendars
+      .map((calendar) => {
+        return `
+        <div>
+        <div class="calendar-date">${calendar.year}년 ${calendar.month+1}월</div>
+        <div class="calendar-box">
+        <ul>
+        ${`<li></li>`.repeat(calendar.firstDay)}
+            ${Array.from({ length: calendar.day }, (_, i) => i + 1)
+              .map((el) => {
+                return `<li>${el}</li>`;
+              })
+              .join("")}
+          </ul>
+        </div>
+    </div>
+      `;
+      })
+      .join("")}
+    </div>
   </div>
-        `;
+</div>
+<div class="calendar-option">
+  <ul>
+    <li>정확한 날짜</li>
+    <li>+- 1일</li>
+    <li>+- 3일</li>
+    <li>+- 7일</li>
+  </ul>
+</div>
+`;
   }
   setEvent() {}
-  createCalendar() {}
 }

--- a/dist/js/components/header/search/searchItem/Calendar.js
+++ b/dist/js/components/header/search/searchItem/Calendar.js
@@ -17,11 +17,11 @@ export default class Calendar extends Component {
       },
       calendars: [],
     };
-    this.initdefaultState();
-  }
-  initdefaultState() {
     const [year, month] = this.state.currentDate;
-    this.state.calendars = [
+    this.state.calendars = this.getNewCalendar(year, month);
+  }
+  getNewCalendar(year, month) {
+    return [
       this.getDateState(year, month - 1),
       this.getDateState(year, month),
       this.getDateState(year, month + 1),
@@ -29,11 +29,8 @@ export default class Calendar extends Component {
     ];
   }
   getDateState(year, month) {
-    console.log(year, month);
-    const date = new Date(year, month, 0);
+    const date = new Date(year, month + 1, 0);
     const firstDay = new Date(year, month, 1);
-    console.log(firstDay.getDay());
-    console.log(" ");
     return {
       year: date.getFullYear(),
       month: date.getMonth() + 1,
@@ -51,8 +48,8 @@ export default class Calendar extends Component {
 <div class="calendar-container">
   <div class="calendar-fixed-box">
     <div class="calendar-day-control">
-      <div>&lt;</div>
-      <div>&gt;</div>
+      <div class ="slideBtn" data-direction="prev">&lt;</div>
+      <div class ="slideBtn" data-direction="next">&gt;</div>
     </div>
     <div class="calendar-day-box">
       <ul class="calendar-day">
@@ -81,7 +78,7 @@ export default class Calendar extends Component {
       .map((calendar) => {
         return `
         <div>
-        <div class="calendar-date">${calendar.year}년 ${calendar.month+1}월</div>
+        <div class="calendar-date">${calendar.year}년 ${calendar.month}월</div>
         <div class="calendar-box">
         <ul>
         ${`<li></li>`.repeat(calendar.firstDay)}
@@ -109,5 +106,31 @@ export default class Calendar extends Component {
 </div>
 `;
   }
-  setEvent() {}
+  setEvent() {
+    this.addEvent("click", ".slideBtn", ({ target }) => {
+      const $translateBox = this.$target.querySelector(".translate-box");
+      const direction = target.dataset.direction === "prev" ? -1 : +1;
+      if (direction === 1) {
+        $translateBox.style.transform = "translate(-50.2rem)";
+      } else {
+        $translateBox.style.transform = "translate(0rem)";
+      }
+      this.state.direction = direction;
+    });
+
+    this.addEvent("transitionend", ".translate-box", () => {
+      const [year, month] = this.state.currentDate;
+      const direction = this.state.direction;
+      const newDate = new Date(year, month + direction);
+
+      const newYear = newDate.getFullYear();
+      const newMonth = newDate.getMonth();
+
+      const calendars = this.getNewCalendar(newYear, newMonth);
+
+      this.setState({ calendars, currentDate: [newYear, newMonth] });
+    });
+  }
+  pre() {}
+  next() {}
 }

--- a/dist/js/components/header/search/searchItem/Guest.js
+++ b/dist/js/components/header/search/searchItem/Guest.js
@@ -2,7 +2,7 @@ import Component from "../../../../core/Component.js";
 
 export default class Guest extends Component {
   setup() {
-    this.$target.classList.add("guest");
+    this.$target.classList.add("item-guest");
   }
   getTemplate() {
     return `


### PR DESCRIPTION
## 🎯 step3에서 할 목록

- [x] 1. 햄버거 UI 클릭시 메뉴 레이어 열기
- [x] 2. 메뉴 레이어 외에 다른곳 클릭시에만 메뉴 레이어 닫기 
- [x] 3. 숙소/체험 클릭시 그에 맞는 searchBox로 변경
- [x] 4. 체험 - 날짜 선택시 두 달치 캘린더 레이어 열기
- [x] 5. 캘린더 좌, 우 클릭으로 달 변경 
- [ ] 6. 날짜 선택하고 날짜 입력란에 추가
- [ ] 7. 캘린더 레이어 외에 다른 곳 클릭시 캘린더 레이어 닫기 


## 🎯🎯 추가적으로 할 일 목록

- [x] 1. 햄버거 메뉴 열기, 닫기 시 height 애니메이션  
- [x] 2. 숙소/체험 hover, focus 일때 하단 바 생성 및 애니메이션
- [x] 3. 캘린더 좌우 이동 애니메이션


## 회고

현재 사용중인 setState - render - setEvent(이제부터 편의상 SRS 방식이라고 부를랜다..) 방식의 경우 html, css로 먼저 다 만들고 이 형태로 옮기는게 나은가? 하는 생각이 든다.
prittier에 템플릿 리터럴을 html로 인식해서 정렬해주는 기능이 있는지 모르겠으나 
html 디버깅?을 에디터단에서 어느정도 할 수 있는데 템플릿 리터럴로 감싸면 문자로 인식해서 잡히지 않는다
자동완성도 안 되고 태그가 제대로 닫혔는지도 알 수 없어서 .. 

html, css가 시간이 더 걸리는거 같다. 크기 단위를 고정값으로 할지 %로할지 명확한 기준이 없어서  %로 하다보면 여러가지 문제가 생긴다. height 값을 width와 같이 하고 싶을 때라던가, 자식 요소의 크기를 부여할 때 고정값에 비해 생각지 못 한 오류? 동작 안 함?이 발생하는 듯..  %를 꼭 써야하는게 아니면 고집하지 말아야겠다.

또한 SRS 방식에서 늘 느꼈던 '애니메이션을 어떻게 부여할것인가'하는 문제가 깔끔히 해결되지 않는다. 
저번 PR에서도 언급한 '이미 변화된 상태'를 innerHTML에 때려넣기 때문에 '돔 객체의 CSS 속성값이 변하는 과정이 없다'

임시방편으로 애니메이션을 먼저 적용해서 시각적으로 움직이는 것을 보여주고, 
해당 DOM에 transitionend 이벤트핸들러를 걸어 트랜지션이 끝나면 setState로 값을 변환하고 '바뀐 값으로 렌더링한다' 

뭔가 일을 두번하는 느낌이지만 아직까지 깔끔한 해결책을 찾지 못 하는 상황 ... 

아 그리고 자꾸 commit을 짧게 하지 못함... 

## 질문



 ##  📄  데모 페이지

[리잉크으](https://codesqurd-master-dd.github.io/fe-w12-airbnb/dist/index.html)