### PR TITLE
[ DD ] Airbnb clone coding - Calendar Final

### DIFF
--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -278,6 +278,11 @@ header .calendar-box > ul > li > div {
   justify-content: center;
   border-radius: 50%;
 }
+header .calendar-box > ul > li > div.clicked {
+  background: black;
+  color: white;
+}
+
 header .calendar-box ul > li.notPassed > div:hover {
   cursor: pointer;
   box-shadow: 0 0 0 1px black;

--- a/dist/js/components/header/search/SearchBox.js
+++ b/dist/js/components/header/search/SearchBox.js
@@ -6,6 +6,8 @@ export default class SearchBox extends Component {
   setup() {
     this.state = {
       searchItem: "stayCheckIn",
+      startDate: "",
+      endDate: "",
     };
   }
   getTemplate() {
@@ -107,28 +109,3 @@ export default class SearchBox extends Component {
     });
   }
 }
-
-// {
-//   year: 2021,
-//   month: 1,
-//   day: 31,
-//   firstDay: 5,
-// },
-// {
-//   year: 2021,
-//   month: 2,
-//   day: 28,
-//   firstDay: 1,
-// },
-// {
-//   year: 2021,
-//   month: 3,
-//   day: 31,
-//   firstDay: 1,
-// },
-// {
-//   year: 2021,
-//   month: 4,
-//   day: 30,
-//   firstDay: 4,
-// },

--- a/dist/js/components/header/search/searchItem/code-review-Calendar.js
+++ b/dist/js/components/header/search/searchItem/code-review-Calendar.js
@@ -1,0 +1,251 @@
+import Component from "../../../../core/Component.js";
+
+export default class Calendar extends Component {
+  setup() {
+    this.$target.classList.add("item-calendar");
+    this.state = {
+      mode: "waiting", // wait, selecting, complete
+      currentDate: this.getCurrentDate(),
+      startDate: null,
+      endDate: null,
+      calendars: [],
+    };
+    const [year, month] = this.state.currentDate;
+    this.state.calendars = this.getNewCalendars(year, month);
+  }
+  getNewCalendars(year, month) {
+    return [
+      this.getDateState(year, month - 1),
+      this.getDateState(year, month),
+      this.getDateState(year, month + 1),
+      this.getDateState(year, month + 2),
+    ];
+  }
+  getDateState(year, month) {
+    const date = new Date(year, month + 1, 0);
+    const firstDay = new Date(year, month, 1);
+    return {
+      year: date.getFullYear(),
+      month: date.getMonth() + 1,
+      day: date.getDate(),
+      firstDay: firstDay.getDay(),
+    };
+  }
+  getCurrentDate() {
+    const current = new Date();
+    return [current.getFullYear(), current.getMonth()];
+  }
+  getTemplate() {
+    const { calendars } = this.state;
+    return `
+<div class="calendar-container">
+  <div class="calendar-fixed-box">
+    <div class="calendar-day-control">
+      <div class ="slideBtn" data-direction="prev">&lt;</div>
+      <div class ="slideBtn" data-direction="next">&gt;</div>
+    </div>
+    <div class="calendar-day-box">
+      ${`<ul class="calendar-day">
+        <li>일</li>
+        <li>월</li>
+        <li>화</li>
+        <li>수</li>
+        <li>목</li>
+        <li>금</li>
+        <li>토</li>
+      </ul>`.repeat(2)}
+    </div>
+  </div>
+  <div class="calendar-list">
+    <div class="translate-box">
+    ${calendars
+      .map((calendar) => {
+        return `
+        <div>
+        <div class="calendar-date">${calendar.year}년 ${calendar.month}월</div>
+        <div class="calendar-box">
+        <ul>
+        ${`<li><div></div></li>`.repeat(calendar.firstDay)}
+            ${Array.from({ length: calendar.day }, (_, i) => i + 1)
+              .map((el) => {
+                const date = `${calendar.year}-${calendar.month}-${el}`;
+                return `
+                <li class="${this.isPassedDay(date) ? "passed" : "notPassed"}">
+                  <div 
+                    class="${
+                      (this.state.startDate === date ||
+                        this.state.endDate === date) &&
+                      "clicked"
+                    }" 
+                    data-date="${calendar.year}-${calendar.month}-${el}">
+                    ${el}
+                  </div>
+                </li>`;
+              })
+              .join("")}
+          </ul>
+        </div>
+    </div>
+      `;
+      })
+      .join("")}
+    </div>
+  </div>
+</div>
+<div class="calendar-option">
+  <ul>
+    <li>정확한 날짜</li>
+    <li>+- 1일</li>
+    <li>+- 3일</li>
+    <li>+- 7일</li>
+  </ul>
+</div>
+`;
+  }
+  setState(newState) {
+    super.setState(newState);
+    const { startDate, endDate } = this.state;
+    const [startY, startM, startD] = startDate.split("-");
+    const checkIn = document.getElementById("stayCheckIn");
+    const checkOut = document.getElementById("stayCheckOut");
+
+    checkIn.value = `${startM}월 ${startD}일`;
+
+    if (!endDate) {
+      checkOut.value = "";
+      return;
+    }
+    const [endY, endM, endD] = endDate.split("-");
+    checkOut.value = `${endM}월 ${endD}일`;
+  }
+  setEvent() {
+    this.addEvent("click", ".slideBtn", ({ target }) => {
+      const $translateBox = this.$target.querySelector(".translate-box");
+      const direction = target.dataset.direction === "prev" ? -1 : +1;
+      if (direction === 1) {
+        $translateBox.style.transform = "translate(-50.2rem)";
+      } else {
+        $translateBox.style.transform = "translate(0rem)";
+      }
+      this.state.direction = direction;
+    });
+
+    this.addEvent("transitionend", ".translate-box", ({ target }) => {
+      const [year, month] = this.state.currentDate;
+      const direction = this.state.direction;
+      const newDate = new Date(year, month + direction);
+
+      const newYear = newDate.getFullYear();
+      const newMonth = newDate.getMonth();
+
+      const calendars = this.getNewCalendars(newYear, newMonth);
+      this.setState({ calendars, currentDate: [newYear, newMonth] });
+    });
+    this.addEvent("click", "[data-date]", ({ target }) => {
+      const { mode } = this.state;
+      const { startDate, endDate } = this.state;
+      const targetDate = target.dataset.date;
+      switch (mode) {
+        case "waiting":
+          if (!startDate) {
+            this.setState({ startDate: targetDate });
+            this.state.mode = "selecting";
+            return;
+          }
+          break;
+        case "selecting":
+          if (targetDate === startDate) {
+            this.setState({ startDate: null });
+            this.state.mode = "waiting";
+            return;
+          }
+          if (this.isFuturethanPivotDate(startDate, targetDate)) {
+            this.setState({ endDate: targetDate });
+            this.state.mode = "complete";
+            this.fillBetweenStartAndEnd();
+          } else {
+            this.setState({ startDate: targetDate, endDate: null });
+          }
+          break;
+        case "complete":
+          if (targetDate === endDate) {
+            this.setState({ endDate: null });
+            this.state.mode = "selecting";
+            return;
+          }
+          if (targetDate === startDate) {
+            this.setState({ startDate: null, endDate: null });
+            this.state.mode = "waiting";
+            return;
+          }
+          if (this.isFuturethanPivotDate(startDate, targetDate)) {
+            this.setState({ endDate: targetDate });
+            this.fillBetweenStartAndEnd();
+          }
+          break;
+        default:
+          console.log("error");
+      }
+    });
+    this.addEvent("mouseover", "[data-date]", ({ target }) => {
+      if (this.state.mode === "complete") return;
+      const { startDate } = this.state;
+      const targetDate = target.dataset.date;
+      if (startDate && this.isFuturethanPivotDate(startDate, targetDate)) {
+        target.classList.add("clicked");
+        this.state.endDate = targetDate;
+        this.fillBetweenStartAndEnd();
+      }
+    });
+    this.addEvent("mouseout", "[data-date]", ({ target }) => {
+      if (this.state.mode === "complete") return;
+      const { startDate } = this.state;
+      const targetDate = target.dataset.date;
+      if (startDate === targetDate) return;
+      if (target.classList.contains("clicked")) {
+        target.classList.remove("clicked");
+        this.fillBetweenStartAndEnd();
+      }
+    });
+  }
+  setEndDate(targetDate) {
+    this.state.endDate = targetDate;
+  }
+  fillBetweenStartAndEnd() {
+    const { startDate, endDate } = this.state;
+    if (!startDate || !endDate) return;
+    const days = [...this.$target.querySelectorAll("[data-date]")];
+    days.map((day) => (day.closest("li").style.backgroundColor = "white"));
+    days
+      .filter(
+        (day) =>
+          !this.isFuturethanPivotDate(day.dataset.date, startDate) &&
+          this.isFuturethanPivotDate(day.dataset.date, endDate)
+      )
+      .map((filteredDay) => {
+        const $li = filteredDay.closest("li");
+        $li.style.backgroundColor = "rgb(170,170,170)";
+        $li.style.borderRadius = "0 0 0 0";
+      });
+    const [$start, $end] = [...this.$target.querySelectorAll(".clicked")];
+    $start.closest("li").style.borderRadius = "50% 0 0 50%";
+    $start.closest("li").style.backgroundColor = "rgb(170,170,170)";
+    if (!$end) return;
+    $end.closest("li").style.borderRadius = "0 50% 50% 0";
+  }
+  isFuturethanPivotDate(pivotDate, targetDate) {
+    const pivot = new Date(pivotDate);
+    const target = new Date(targetDate);
+    return pivot <= target;
+  }
+  getClickedLi(target) {
+    return target.closest("li");
+  }
+  isPassedDay(date) {
+    const today = new Date();
+    today.setDate(today.getDate() - 1);
+    const targetDate = new Date(date);
+    return today > targetDate;
+  }
+  calStartOrEndDate(date) {}
+}


### PR DESCRIPTION
## 🎯 step4 에서 진행한 항목

- [x] 1. 날짜 선택하고 날짜 입력란에 추가
- [x] 2. 캘린더 내부 날짜 최초 클릭시 checkIn date로 지정
- [x] 3. checkIn date 이후 / hover시 선대신 면으로 날짜표시, checkIn ~ hover 날짜(과거x) 사이값 표시 
- [x] 4. waiting, selecting, complete 상태 3가지로 구분해서 그에 따른 클릭, hover 다르게 동작

## 🎯🎯 진행하지 못 한 목록

- [ ] 1. 캘린더 레이어 외에 다른 곳 클릭시 캘린더 레이어 닫기 
- [ ] 2. css 모듈화 및 scss로 정리

## 회고

클론코딩을 하면서 페이지 하나에 생각보다 고려할 요소가 많다고 생각했다.
 
### HTML

의미론적인 구조를 고려하는 것은 당연히 중요하다.

하지만 event, css를 위한 구조를 고려하는 것도 상당히 중요한 것 같다.

css를 적용하다보면 div태그로 한 번 더 감싸야하는 일이 생기거나 구조를 변경하는 등 수정이 잦아지고, HTML은 디버깅도 어려워서 그러다 코드가 꼬이기도 한다. 

초반 설계를 미리 세세하게 하는게 오히려 시간 절약이 될지도..

### Class, CSS

네이밍 규칙은 여전히 어렵다.

class를 어느 태그에 부여할 것인가?는 상당히 고민되는 주제인것 같다.
적당한 크기?의 요소에 class를 부여하고 그 하위 항목은 선택자 조합으로 스타일을 지정하다보면 선택자가 길어진다.

그러다보면 css를 덮어씌울 때 우선순위가 꼬이기도 하고 알아보기 힘들다. scss를 쓰면 좀 더 나아지겠지만.. 

class의 본래 용도는 스타일 적용이다. 스타일 지정 없이 javascript에서 해당 돔을 탐색하기 위해서만 class를 사용해도 좋은 방식일까? 

### JavaScript 

금요일에 끝내려고 기능구현에 집중하다보니 계속 고수해오던 setState - render - setEvent 방식에 어긋난 구현이 덕지덕지 달라붙었다. 
모든 변화를 상태관리로써 해내지 못 하고 필요한 dom을 서치하고 지정, 조작하는 제이쿼리 방식이랑 섞여버렸다.

그 외에 애니메이션이나 디테일한 변화를 줘야할 때 이 구조에서 자주 고민이 됐던것은 
**상태가 변하긴 하지만 굳이 컴포넌트를 다시 렌더링 할 필요까지는 없는** 경우, 

- setState를 사용해서 상태를 변경할 것인가
- this.setState.someState = newState로 직접 상태를 변경시킬 것인가.

이 두가지 고민을 하게 되었다.

일관성을 위해서라면 첫 번째, setState를 사용해야한다. 이 경우 반드시 render-setEvent과정을 거치게 되어 불필요한 렌더링과 예상치 못한 문제가 발생한다. 

예를들어 mouseover 이벤트를 받아 해당 target의 dataset에서 날짜값을 받고, 비교를 통해 시작날과 현재 hover중인 날 사이를 채우거나, hover중인 날을 검은색으로 채우거나 하는 등의 동작이 있다.
이 때 hover중인 날의 dataset.date 값을 상태의 endDate에 넣어줘야하는데 setState를 통해 업데이트하면 
**마우스가 그 위에 있는채로  다시 렌더링되어 mouseover이벤트가 발생하고, 다시 setState가 발생..** 즉 무한 루프가 돌아버린다.
그래서 이 경우에는 다시 렌더링 되지 않도록 직접 값을 변경했다.

물론 구조를 좀 더 매끄럽게 짜거나 이벤트를 방지하면 해결될 수도 있지만 이 외에도 여러 가지 경우로 볼 때 수정이 필요한 구조다.

이 구조는 상태가 변경되면 '컴포넌트 전체를 다시 렌더링한다'는 형태이므로 작은 부분 하나를 바꾸기 위해 전체를 리렌더링하는 것은 불필요하다고 생각된다.

setState를 두 종류로 나누어 render 함수를 부르는것 / 부르지 않는 것으로 나누거나 
상태값을 render에서 사용하는 것과 그렇지 않은 것으로 나누거나 하는 식의 구분이 필요할지도 .. 

그렇다고 모든 부분을 컴포넌트화해서 나누는 것도 과하게 나누는 것 같고 컴포넌트 내부에서도 마치 컴포넌트마냥 그 부분만 리렌더링하는 방식이 가장 좋을 것같다. 
리액트를 잠깐 써봤을 때 아마 그런 기능이 있었다. 정말 필요한 부분만 다시 렌더링하는 .. 
가상돔이 이 경우에 적용된다고 한거 같기도???

아무튼 이 구조는 처음 쓸때는 꽤 좋았는데 애니메이션, 작은 부분의 상태관리 or 리렌더링 구조를 생각했을 때 더 뜯어 고칠 필요가 있다. 근데 당연한 소리다. 이걸로 다 되면 프레임워크를 왜 쓰겠는가. 

## 질문




 ##  📄  데모 페이지

[리잉크으](https://codesqurd-master-dd.github.io/fe-w12-airbnb/dist/index.html)